### PR TITLE
Migrate volumes to gp3

### DIFF
--- a/kubernetes/elasticsearch/README.md
+++ b/kubernetes/elasticsearch/README.md
@@ -1,0 +1,18 @@
+After you deploy this chart you will have to do the following
+1) Add one log to the database:
+```
+    curl -X POST -k \
+      -u elastic:<elastic-password> \
+      https://elasticsearch.postrix.io/logs-2025.05.08/_doc \
+      -H "Content-Type: application/json" \
+      -d '{
+        "message": "This is a test log message",
+        "service": "test-application",
+        "level": "log",
+        "hostname": "my-test-host",
+        "@timestamp": "2025-05-08T18:30:45.123Z"
+      }'
+```
+
+2) Create a Data View. Name it "App" and name the index-pattern to "logs-*"
+3) Search for the log in the discover page to see if it worked

--- a/kubernetes/elasticsearch/templates/storageclass.yaml
+++ b/kubernetes/elasticsearch/templates/storageclass.yaml
@@ -1,0 +1,31 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gp3-elasticsearch
+provisioner: ebs.csi.aws.com
+parameters:
+  type: gp3
+  encrypted: "false"
+  # Tags for the EBS volume
+  tagSpecification_1: "Name=elasticsearch-persistent-storage"
+  tagSpecification_2: "Application=elasticsearch"
+  tagSpecification_3: "Component=database"
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: false
+reclaimPolicy: Delete
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gp3-kibana
+provisioner: ebs.csi.aws.com
+parameters:
+  type: gp3
+  encrypted: "false"
+  # Tags for the EBS volume
+  tagSpecification_1: "Name=kibana-persistent-storage"
+  tagSpecification_2: "Application=kibana"
+  tagSpecification_3: "Component=database"
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: false
+reclaimPolicy: Delete

--- a/kubernetes/elasticsearch/values/defaults.yaml
+++ b/kubernetes/elasticsearch/values/defaults.yaml
@@ -13,8 +13,8 @@ elasticsearch:
         memory: 2Gi
     persistence:
       enabled: true
-      storageClass: gp2
-      size: 10Gi
+      storageClass: gp3-elasticsearch
+      size: 2Gi
     
   # Disable additional nodes for minimal setup
   data:
@@ -73,8 +73,8 @@ elasticsearch:
         
     persistence:
       enabled: true
-      storageClass: gp2
-      size: 2Gi
+      storageClass: gp3-kibana
+      size: 1Gi
       
     ingress:
       enabled: true

--- a/kubernetes/postgresql/templates/storageclass.yaml
+++ b/kubernetes/postgresql/templates/storageclass.yaml
@@ -1,0 +1,15 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gp3-postgresql
+provisioner: ebs.csi.aws.com
+parameters:
+  type: gp3
+  encrypted: "false"
+  # Tags for the EBS volume
+  tagSpecification_1: "Name=postgresql-persistent-storage"
+  tagSpecification_2: "Application=postgresql"
+  tagSpecification_3: "Component=database"
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: false
+reclaimPolicy: Delete

--- a/kubernetes/postgresql/values/defaults.yaml
+++ b/kubernetes/postgresql/values/defaults.yaml
@@ -13,8 +13,8 @@ postgresql:
   primary:
     persistence:
       enabled: true
-      storageClass: gp2
-      size: 8Gi
+      storageClass: gp3-postgresql
+      size: 2Gi
     resources:
       requests:
         memory: 256Mi

--- a/kubernetes/redis/templates/storageclass.yaml
+++ b/kubernetes/redis/templates/storageclass.yaml
@@ -1,0 +1,15 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gp3-redis
+provisioner: ebs.csi.aws.com
+parameters:
+  type: gp3
+  encrypted: "false"
+  # Tags for the EBS volume
+  tagSpecification_1: "Name=redis-persistent-storage"
+  tagSpecification_2: "Application=redis"
+  tagSpecification_3: "Component=database"
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: false
+reclaimPolicy: Delete

--- a/kubernetes/redis/values/defaults.yaml
+++ b/kubernetes/redis/values/defaults.yaml
@@ -5,7 +5,7 @@ redis:
     persistence:
       enabled: true 
       size: 1Gi
-      storageClass: gp2
+      storageClass: gp3-redis
     service:
       type: ClusterIP
       port: 6379


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dedicated storage classes for Elasticsearch, Kibana, PostgreSQL, and Redis using gp3 AWS EBS volumes for improved storage management.
  - Introduced a launch template for EKS node groups to provide explicit control over root volume configuration.

- **Documentation**
  - Added a README with step-by-step post-deployment instructions for the Kubernetes Elasticsearch deployment.

- **Refactor**
  - Updated default storage classes and reduced storage sizes for Elasticsearch, Kibana, PostgreSQL, and Redis components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->