### PR TITLE
Reduce pod resources

### DIFF
--- a/kubernetes/cannon/values/defaults.yaml
+++ b/kubernetes/cannon/values/defaults.yaml
@@ -11,5 +11,5 @@ resources:
     cpu: 200m
     memory: 512Mi
   requests:
-    cpu: 100m
+    cpu: 5m
     memory: 256Mi

--- a/kubernetes/capish/values/defaults.yaml
+++ b/kubernetes/capish/values/defaults.yaml
@@ -11,5 +11,5 @@ resources:
     cpu: 200m
     memory: 512Mi
   requests:
-    cpu: 100m
+    cpu: 5m
     memory: 256Mi

--- a/kubernetes/cluster-autoscaler/values/defaults.yaml
+++ b/kubernetes/cluster-autoscaler/values/defaults.yaml
@@ -4,27 +4,4 @@ awsRegion: us-east-1
 rbac:
   serviceAccount:
     annotations:
-      eks.amazonaws.com/role-arn: arn:aws:iam::384389382109:role/postrix-cluster-autoscaler-role
-extraArgs:
-  # More conservative scale-down timing
-  scale-down-delay-after-add: 10m
-  scale-down-unneeded-time: 10m
-  unremovable-node-recheck-timeout: 5m
-  
-  # Add utilization threshold to prevent premature scale-down
-  scale-down-utilization-threshold: 0.5
-  
-  # Limit scale-down to one node at a time
-  max-nodes-total: 10
-  max-node-provision-time: 15m
-  
-  # Skip nodes with system pods and local storage
-  skip-nodes-with-local-storage: true
-  skip-nodes-with-system-pods: true
-  
-  # More conservative resource thresholds
-  scale-down-gpu-utilization-threshold: 0.5
-  scale-down-non-empty-candidates-count: 30
-  
-  # Logging for debugging
-  v: 1 
+      eks.amazonaws.com/role-arn: arn:aws:iam::384389382109:role/postrix-cluster-autoscaler-role 

--- a/kubernetes/cluster-autoscaler/values/defaults.yaml
+++ b/kubernetes/cluster-autoscaler/values/defaults.yaml
@@ -6,6 +6,25 @@ rbac:
     annotations:
       eks.amazonaws.com/role-arn: arn:aws:iam::384389382109:role/postrix-cluster-autoscaler-role
 extraArgs:
-  scale-down-delay-after-add: 2m
-  scale-down-unneeded-time: 2m
-  unremovable-node-recheck-timeout: 1m 
+  # More conservative scale-down timing
+  scale-down-delay-after-add: 10m
+  scale-down-unneeded-time: 10m
+  unremovable-node-recheck-timeout: 5m
+  
+  # Add utilization threshold to prevent premature scale-down
+  scale-down-utilization-threshold: 0.5
+  
+  # Limit scale-down to one node at a time
+  max-nodes-total: 10
+  max-node-provision-time: 15m
+  
+  # Skip nodes with system pods and local storage
+  skip-nodes-with-local-storage: true
+  skip-nodes-with-system-pods: true
+  
+  # More conservative resource thresholds
+  scale-down-gpu-utilization-threshold: 0.5
+  scale-down-non-empty-candidates-count: 30
+  
+  # Logging for debugging
+  v: 1 

--- a/kubernetes/elasticsearch/values/defaults.yaml
+++ b/kubernetes/elasticsearch/values/defaults.yaml
@@ -6,10 +6,10 @@ elasticsearch:
     replicaCount: 1
     resources:
       limits:
-        cpu: 2000m
+        cpu: 1000m
         memory: 4Gi
       requests:
-        cpu: 500m
+        cpu: 100m
         memory: 1Gi
     persistence:
       enabled: true
@@ -68,7 +68,7 @@ elasticsearch:
         cpu: 1000m
         memory: 2Gi
       requests:
-        cpu: 250m
+        cpu: 100m
         memory: 1Gi
         
     persistence:

--- a/kubernetes/elasticsearch/values/defaults.yaml
+++ b/kubernetes/elasticsearch/values/defaults.yaml
@@ -69,7 +69,7 @@ elasticsearch:
         memory: 2Gi
       requests:
         cpu: 250m
-        memory: 512Mi
+        memory: 1Gi
         
     persistence:
       enabled: true

--- a/kubernetes/joby/values/defaults.yaml
+++ b/kubernetes/joby/values/defaults.yaml
@@ -11,5 +11,5 @@ resources:
     cpu: 200m
     memory: 512Mi
   requests:
-    cpu: 100m
+    cpu: 5m
     memory: 256Mi

--- a/kubernetes/postgresql/values/defaults.yaml
+++ b/kubernetes/postgresql/values/defaults.yaml
@@ -17,11 +17,11 @@ postgresql:
       size: 2Gi
     resources:
       requests:
-        memory: 256Mi
-        cpu: 250m
+        memory: 128Mi
+        cpu: 100m
       limits:
-        memory: 1Gi
-        cpu: 1000m
+        memory: 512Mi
+        cpu: 500m
 
   ## Network configuration
   service:

--- a/kubernetes/rbac/templates/cluster-autoscaler-role-binding.yaml
+++ b/kubernetes/rbac/templates/cluster-autoscaler-role-binding.yaml
@@ -1,0 +1,14 @@
+# Cluster Autoscaler additional RBAC role binding
+# This binds the additional permissions to the cluster autoscaler service account
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-autoscaler-additional-permissions
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-autoscaler-additional-permissions
+subjects:
+- kind: ServiceAccount
+  name: cluster-autoscaler-aws-cluster-autoscaler
+  namespace: kube-system 

--- a/kubernetes/rbac/templates/cluster-autoscaler-role.yaml
+++ b/kubernetes/rbac/templates/cluster-autoscaler-role.yaml
@@ -1,0 +1,10 @@
+# Cluster Autoscaler additional RBAC permissions
+# This fixes the volumeattachments permission error
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-autoscaler-additional-permissions
+rules:
+- apiGroups: ["storage.k8s.io"]
+  resources: ["volumeattachments"]
+  verbs: ["get", "list", "watch"] 

--- a/services/joby/Dockerfile
+++ b/services/joby/Dockerfile
@@ -4,7 +4,7 @@
 
 # Use the official lightweight Node.js image.
 # https://hub.docker.com/_/node
-FROM --platform=linux/arm64 node:24.0.1-alpine
+FROM --platform=linux/arm64 node:24.0.1-slim
 
 # Set up the workspace directory and cd into it
 WORKDIR /usr/workspace

--- a/services/joby/Dockerfile
+++ b/services/joby/Dockerfile
@@ -4,7 +4,7 @@
 
 # Use the official lightweight Node.js image.
 # https://hub.docker.com/_/node
-FROM --platform=linux/arm64 node:24.0.1-slim
+FROM --platform=linux/arm64 node:24.0.1-alpine
 
 # Set up the workspace directory and cd into it
 WORKDIR /usr/workspace

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -62,6 +62,7 @@ module "aws_eks" {
   cluster_name   = "postrix"
   region         = var.aws_region
   subnet_ids     = module.aws_vpc.subnet_ids  # Use VPC module output instead of hardcoded IDs
+  node_subnet_ids = [module.aws_vpc.subnet_a_id]
 
   providers = {
     aws = aws

--- a/terraform/modules/aws/eks/main.tf
+++ b/terraform/modules/aws/eks/main.tf
@@ -59,7 +59,7 @@ resource "aws_eks_node_group" "postrix_nodes" {
   cluster_name    = aws_eks_cluster.postrix.name
   node_group_name = "${var.cluster_name}-node-group"
   node_role_arn   = aws_iam_role.eks_node.arn
-  subnet_ids      = var.subnet_ids  # Use both AZs to match cluster configuration
+  subnet_ids      = var.subnet_ids
 
   scaling_config {
     desired_size = 2
@@ -67,9 +67,9 @@ resource "aws_eks_node_group" "postrix_nodes" {
     max_size     = 5
   }
 
-  instance_types = ["t4g.medium"]  // ARM Architecture: 0.8$ per day for on-demand, 0.24$ per day for spot(per node)
+  instance_types = ["t4g.small"]
   ami_type       = "AL2023_ARM_64_STANDARD"
-  capacity_type  = "ON_DEMAND" // Switch back to on-demand for reliability
+  capacity_type  = "ON_DEMAND"
 
   launch_template {
     name    = aws_launch_template.postrix_nodes.name

--- a/terraform/modules/aws/eks/main.tf
+++ b/terraform/modules/aws/eks/main.tf
@@ -13,6 +13,11 @@ variable "subnet_ids" {
   type        = list(string)
 }
 
+variable "node_subnet_ids" {
+  description = "A list of subnet IDs for the EKS node group"
+  type        = list(string)
+}
+
 resource "aws_eks_cluster" "postrix" {
   name     = var.cluster_name
   role_arn = aws_iam_role.eks_cluster.arn
@@ -55,21 +60,53 @@ resource "aws_eks_access_policy_association" "postrix_user_admin" {
 # }
 
 // Managed node group for the EKS cluster, specifying instance type and scaling
+// Free trial until end of 2025 for one t4g.small instance
 resource "aws_eks_node_group" "postrix_nodes" {
   cluster_name    = aws_eks_cluster.postrix.name
-  node_group_name = "${var.cluster_name}-node-group"
+  node_group_name = "${var.cluster_name}-node-group-on-demand"
   node_role_arn   = aws_iam_role.eks_node.arn
-  subnet_ids      = var.subnet_ids
+  subnet_ids      = var.node_subnet_ids
 
   scaling_config {
-    desired_size = 2
+    desired_size = 1
     min_size     = 1
-    max_size     = 5
+    max_size     = 1
   }
 
   instance_types = ["t4g.small"]
   ami_type       = "AL2023_ARM_64_STANDARD"
   capacity_type  = "ON_DEMAND"
+
+  launch_template {
+    name    = aws_launch_template.postrix_nodes.name
+    version = aws_launch_template.postrix_nodes.latest_version
+  }
+
+  tags = {
+    "k8s.io/cluster-autoscaler/enabled" = "true"
+    "k8s.io/cluster-autoscaler/${var.cluster_name}" = "owned"
+  }
+
+  lifecycle {
+    ignore_changes = [scaling_config[0].desired_size]
+  }
+}
+
+resource "aws_eks_node_group" "postrix_nodes_spot" {
+  cluster_name    = aws_eks_cluster.postrix.name
+  node_group_name = "${var.cluster_name}-node-group-spot"
+  node_role_arn   = aws_iam_role.eks_node.arn
+  subnet_ids      = var.node_subnet_ids
+
+  scaling_config {
+    desired_size = 1
+    min_size     = 1
+    max_size     = 2
+  }
+
+  instance_types = ["t4g.large"]
+  ami_type       = "AL2023_ARM_64_STANDARD"
+  capacity_type  = "SPOT"
 
   launch_template {
     name    = aws_launch_template.postrix_nodes.name
@@ -292,7 +329,9 @@ resource "aws_iam_role_policy" "cluster_autoscaler" {
           "autoscaling:SetDesiredCapacity",
           "autoscaling:TerminateInstanceInAutoScalingGroup",
           "ec2:DescribeLaunchTemplateVersions",
-          "ec2:DescribeInstanceTypes"
+          "ec2:DescribeInstanceTypes",
+          "eks:DescribeNodegroup",
+          "eks:DescribeCluster"
         ]
         Resource = ["*"]
       }

--- a/terraform/modules/aws/vpc/outputs.tf
+++ b/terraform/modules/aws/vpc/outputs.tf
@@ -6,4 +6,14 @@ output "vpc_id" {
 output "subnet_ids" {
   description = "List of subnet IDs"
   value       = [aws_subnet.subnet_a.id, aws_subnet.subnet_b.id]
-} 
+}
+
+output "subnet_a_id" {
+  description = "Subnet A ID"
+  value       = aws_subnet.subnet_a.id
+}
+
+output "subnet_b_id" {
+  description = "Subnet B ID"
+  value       = aws_subnet.subnet_b.id
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Reduced default CPU resource requests from 100m to 5m for Cannon, Capish, and Joby services.
  - Lowered CPU and memory resource requests and limits for PostgreSQL and Elasticsearch components.
  - Increased default memory request for Kibana in Elasticsearch from 512Mi to 1Gi.
  - Updated AWS EKS node groups to include a dedicated on-demand group with t4g.small instances and a new spot group with t4g.large instances.
  - Added separate outputs for subnet A and subnet B IDs in AWS VPC module.
  - Removed specific scale-down timing arguments from cluster autoscaler configuration.
  - Added new RBAC ClusterRole and ClusterRoleBinding to grant additional permissions for the cluster autoscaler.
  - Enhanced IAM permissions for cluster autoscaler to describe EKS node groups and clusters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->